### PR TITLE
Remove `private: false` from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@lune-climate/eslint-config",
-  "private": false,
   "version": "0.0.1-alpha.1",
   "description": "The Lune Climate shared ESLint configuration",
   "main": "index.js",


### PR DESCRIPTION
We reference this package with `git+https:`.

@0bex0 is getting a checksum error when installing it as dependency.

This issue has occured before: https://github.com/yarnpkg/berry/issues/2399.

I inspected the zipped packages and noticed the difference is `private:` in package.json.

I have therefore decided to remove the attribute and see what happens.

<img width="1721" alt="Screenshot 2024-06-12 at 18 44 57" src="https://github.com/lune-climate/eslint-config/assets/1833249/88975b26-17be-454b-af56-011abd18a716">

