### PR TITLE
Update the typesript-eslint plugin version range

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "prettier": "^3.0.3"
   },
   "peerDependencies": {
-    "@typescript-eslint/eslint-plugin": "^5.0.0 || ^6.7.5",
+    "@typescript-eslint/eslint-plugin": "^7.0.0 || ^8.0.0",
     "eslint": "^7.0.0 || ^8.51.0",
     "eslint-plugin-simple-import-sort": "^10.0.0"
   },


### PR DESCRIPTION
We've migrated to 7.x or 8.x in our projects.