### PR TITLE
Explicitly enable promise recommended rules

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ module.exports = {
         browser: true,
         es2021: true,
     },
-    extends: ['standard', 'prettier', 'eslint:recommended'],
+    extends: ['standard', 'prettier', 'eslint:recommended', 'plugin:promise/recommended'],
     parser: '@typescript-eslint/parser',
     parserOptions: {
         ecmaVersion: 12,

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "peerDependencies": {
     "@typescript-eslint/eslint-plugin": "^5.0.0 || ^6.7.5",
     "eslint": "^7.0.0 || ^8.51.0",
+    "eslint-plugin-promise": "^7.1.0",
     "eslint-plugin-simple-import-sort": "^10.0.0"
   },
   "dependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -12,6 +12,11 @@ eslint-config-standard@^17.1.0:
   resolved "https://registry.yarnpkg.com/eslint-config-standard/-/eslint-config-standard-17.1.0.tgz#40ffb8595d47a6b242e07cbfd49dc211ed128975"
   integrity sha512-IwHwmaBNtDK4zDHQukFDW5u/aTb8+meQWZvNFWkiGmbWjD6bqyuSSBxxXKkCftCUzc1zwCH2m/baCNDLGmuO5Q==
 
+eslint-plugin-promise@^7.1.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-promise/-/eslint-plugin-promise-7.1.0.tgz#06b3ad6d36b3c3ef3ec201c8a8d97049cf5dbb20"
+  integrity sha512-8trNmPxdAy3W620WKDpaS65NlM5yAumod6XeC4LOb+jxlkG4IVcp68c6dXY2ev+uT4U1PtG57YDV6EGAXN0GbQ==
+
 prettier@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.0.3.tgz#432a51f7ba422d1469096c0fdc28e235db8f9643"


### PR DESCRIPTION
I had a quick look and there are some sensible rules there I believe[1].

Our backend is mostly compatible with this addition.

We currently use eslint-config-standard that does something similar but I plan to get rid of that dependency.

[1] https://www.npmjs.com/package/eslint-plugin-promise