### PR TITLE
Update CI actions to the latest versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,9 @@ jobs:
       matrix:
         node-version: [20.x]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'


### PR DESCRIPTION
Keeping things up to date.

Also we've been experiencing CI failures today[1] and I think the change will resolve them.

    Run actions/setup-node@v2
    Found in cache @ /opt/hostedtoolcache/node/20.19.1/x64
    /opt/hostedtoolcache/node/20.19.1/x64/bin/npm config get cache
    /home/runner/.npm
    Error: getCacheEntry failed: Request timeout: /kSfRgLCOt2WO2sxS2NA4QQgZCOann3ulnl7onJCjWmahrqhFkD/_apis/artifactcache/cache?keys=node-cache-Linux-npm-5b94101182c0f868814e48a976f54b19469531f65d36bd216066489773ca3660&version=50d400d095a6192db0d33c12479fa3b460d8cf4b8e12d9e861e3f3572a68276f

[1] https://github.com/lune-climate/eslint-config/actions/runs/15322758961/job/43109969631