### PR TITLE
Disable the no-use-before-define rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -67,6 +67,9 @@ module.exports = {
         // can be safely used in a string context. We can try to configure this behavior.
         '@typescript-eslint/no-base-to-string': 'off',
 
+        // We find it creates more problems than it solves.
+        '@typescript-eslint/no-use-before-define': 'off',
+
         // Prevents using Big (among others) in string templates
         '@typescript-eslint/restrict-template-expressions': 'off',
 


### PR DESCRIPTION
What it says in the comment, we don't find this rule particularly valuable and it generates errors in the most inconvenient scenarios where we have to move code around (bloats the diff sizes) or add eslint-disable-next-line pragmas to the code, neither of which is nice.

Already disables in at least some of our projects, this patch attempts to centralize that.