### PR TITLE
Enable the n plugin

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,11 +18,7 @@ module.exports = {
         tsconfigRootDir: __dirname,
         project: ['./tsconfig.json'],
     },
-    plugins: [
-        '@typescript-eslint',
-        'n',
-        'simple-import-sort',
-    ],
+    plugins: ['@typescript-eslint', 'n', 'simple-import-sort'],
     rules: {
         // Unnecessary with TS and generates false positives.
         // https://github.com/typescript-eslint/typescript-eslint/blob/181e705887e9e07f0fa28195644cc94e5b4f039d/docs/linting/Troubleshooting.mdx#i-get-errors-from-the-no-undef-rule-about-global-variables-not-being-defined-even-though-there-are-no-typescript-errors

--- a/index.js
+++ b/index.js
@@ -18,7 +18,11 @@ module.exports = {
         tsconfigRootDir: __dirname,
         project: ['./tsconfig.json'],
     },
-    plugins: ['@typescript-eslint', 'simple-import-sort'],
+    plugins: [
+        '@typescript-eslint',
+        'n',
+        'simple-import-sort',
+    ],
     rules: {
         // Unnecessary with TS and generates false positives.
         // https://github.com/typescript-eslint/typescript-eslint/blob/181e705887e9e07f0fa28195644cc94e5b4f039d/docs/linting/Troubleshooting.mdx#i-get-errors-from-the-no-undef-rule-about-global-variables-not-being-defined-even-though-there-are-no-typescript-errors


### PR DESCRIPTION
I made a mistake in an earlier commit where I added a bunch of n/... rules but I forgot to include the plugin so that the rules are actually available.

That resulted in a bunch of errors like

    /lune/backend/src/utils.ts
      1:1  error  Definition for rule 'n/handle-callback-err' was not found    n/handle-callback-err
      1:1  error  Definition for rule 'n/no-callback-literal' was not found    n/no-callback-literal
      1:1  error  Definition for rule 'n/no-deprecated-api' was not found      n/no-deprecated-api
      1:1  error  Definition for rule 'n/no-exports-assign' was not found      n/no-exports-assign
      1:1  error  Definition for rule 'n/no-new-require' was not found         n/no-new-require
      1:1  error  Definition for rule 'n/no-path-concat' was not found         n/no-path-concat
      1:1  error  Definition for rule 'n/process-exit-as-throw' was not found  n/process-exit-as-throw

when I attempted to use the configuration.

Fixes: 45618c56ea53 ("Fix a few regressions (#9)")