### PR TITLE
Widen some peer dependency versions to the latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,10 +24,10 @@
   },
   "peerDependencies": {
     "@typescript-eslint/eslint-plugin": "^7.0.0 || ^8.0.0",
-    "eslint": "^7.0.0 || ^8.51.0",
+    "eslint": "^7.0.0 || ^8.51.0 || ^9.0.0",
     "eslint-plugin-n": "^17.20.0",
     "eslint-plugin-promise": "^7.1.0",
-    "eslint-plugin-simple-import-sort": "^10.0.0"
+    "eslint-plugin-simple-import-sort": "^10.0.0 || ^11.0.0 || ^12.0.0"
   },
   "dependencies": {
     "eslint-config-prettier": "^9.0.0"


### PR DESCRIPTION
This is to allow error-less installation in projects that use the newest ESLint or eslint-plugin-simple-import-sort.

I'm not actually sure the configuration here is compatible with those but we'll find out soon enough, we'll fix problems as they're discovered.